### PR TITLE
[ #39 ] User Authentication leverages Local Storage for Email and AutoLogin

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'theme/app_theme.dart';
-import 'presentation/screens/login_screen.dart'; // or your chosen screen
 import 'presentation/screens/place_bet_view.dart'; // or your chosen screen
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
@@ -12,6 +11,7 @@ import "data/models/match_model.dart";
 import 'dart:convert';
 import 'presentation/viewmodels/bet_viewmodel.dart';
 import 'data/services/connectivity_service.dart';
+import 'presentation/viewmodels/auth_wrapper_viewmodel.dart';
 
 
 // Global instance for local notifications
@@ -93,7 +93,7 @@ class MyApp extends StatelessWidget {
       navigatorKey: navigatorKey,
       title: 'Demo Matches',
       theme: AppTheme.darkTheme,
-      home: const LoginScreen(),
+      home: const AuthWrapper(),
     );
   }
 }

--- a/lib/presentation/screens/login_screen.dart
+++ b/lib/presentation/screens/login_screen.dart
@@ -7,7 +7,9 @@ import 'matches_view.dart';
 import 'package:campus_picks/data/services/auth.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'home_screen.dart';
-import 'package:campus_picks/data/services/backend_api.dart';   // ← NEW
+import 'package:campus_picks/data/services/backend_api.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -39,7 +41,18 @@ class _LoginScreenState extends State<LoginScreen>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _fadeController.forward();
     });
+    _loadSavedEmail();
   }
+
+  Future<void> _loadSavedEmail() async {
+  final prefs = await SharedPreferences.getInstance();
+  final savedEmail = prefs.getString('user_email');
+  if (savedEmail != null) {
+    setState(() {
+      _emailController.text = savedEmail;
+    });
+  }
+}
 
   @override
   void dispose() {
@@ -200,6 +213,9 @@ class _LoginScreenState extends State<LoginScreen>
         email: _emailController.text,
         password: _passwordController.text,
       );
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('user_email', _emailController.text);
 
       // ① Ask backend if the UID exists in SQL
       final uid = FirebaseAuth.instance.currentUser!.uid;

--- a/lib/presentation/screens/matches_view.dart
+++ b/lib/presentation/screens/matches_view.dart
@@ -4,6 +4,8 @@ import '../../data/models/match_model.dart';
 import '../viewmodels/matches_view_model.dart';
 import '../widgets/match_card_factory.dart';
 import '../../data/services/connectivity_service.dart';
+import 'package:campus_picks/data/services/auth.dart';
+import 'package:campus_picks/presentation/screens/login_screen.dart';
 
 class MatchesView extends StatefulWidget {
   const MatchesView({Key? key}) : super(key: key);
@@ -112,6 +114,19 @@ class _MatchesViewState extends State<MatchesView>
           appBar: AppBar(
             title: const Text('Matches'),
             actions: [
+              IconButton(
+                icon: const Icon(Icons.exit_to_app),
+                tooltip: 'Logout',
+                onPressed: () async {
+                  await authService.value.signOut();
+                  if (mounted) {
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(builder: (context) => LoginScreen()),
+                    );
+                  }
+                },
+              ),
               IconButton(
                 icon: Icon(
                   _showOnlyFavorites ? Icons.star : Icons.star_border,

--- a/lib/presentation/viewmodels/auth_wrapper_viewmodel.dart
+++ b/lib/presentation/viewmodels/auth_wrapper_viewmodel.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:campus_picks/presentation/screens/login_screen.dart';
+import 'package:campus_picks/presentation/screens/home_screen.dart';
+
+class AuthWrapper extends StatelessWidget {
+  const AuthWrapper({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user != null) {
+      return const HomeNav(); 
+    } else {
+      return const LoginScreen();
+    }
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,15 +6,23 @@ import FlutterMacOS
 import Foundation
 
 import cloud_firestore
+import connectivity_plus
 import firebase_auth
 import firebase_core
 import flutter_local_notifications
 import geolocator_apple
+import path_provider_foundation
+import shared_preferences_foundation
+import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -536,6 +536,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: c2c8c46297b5d6a80bed7741ec1f2759742c77d272f1a1698176ae828f8e1a18
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.9"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,13 +17,10 @@ dependencies:
   intl: ^0.17.0
   sqflite: ^2.0.0+4
   connectivity_plus: ^6.1.3
-  
+  shared_preferences: ^2.2.2
   http: ^1.3.0
-
   flutter_local_notifications: ^19.0.0
-
   geolocator: ^9.0.2
-
   cached_network_image: ^3.4.1
 
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <cloud_firestore/cloud_firestore_plugin_c_api.h>
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <geolocator_windows/geolocator_windows.h>
@@ -14,6 +15,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   CloudFirestorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("CloudFirestorePluginCApi"));
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FirebaseAuthPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   cloud_firestore
+  connectivity_plus
   firebase_auth
   firebase_core
   geolocator_windows


### PR DESCRIPTION
This pull request closes #39.
It introduces several changes to enhance user authentication, improve state management, and integrate new plugins. The most significant updates include replacing `LoginScreen` with `AuthWrapper` for dynamic navigation based on authentication status, adding functionality to save and load user email using `shared_preferences`, and registering new plugins across platforms.

### Authentication and Navigation Enhancements:
* Replaced the `LoginScreen` with the newly created `AuthWrapper` in `MyApp` to dynamically navigate users to either the `HomeNav` or `LoginScreen` based on authentication status. (`lib/main.dart`, [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L96-R96); `lib/presentation/viewmodels/auth_wrapper_viewmodel.dart`, [[2]](diffhunk://#diff-363ad2c8871be6c888844f8b81174bb6fd370ea9301ec9a997bdf6dd697a4378R1-R18)

### State Persistence:
* Implemented functionality in `LoginScreen` to save the user's email to local storage using `shared_preferences` upon successful login and load it when the screen initializes. (`lib/presentation/screens/login_screen.dart`, [[1]](diffhunk://#diff-5e8281caf244873d624158d989f19b69fa03d9bc76f61b8af665ce7778220813R44-R54) [[2]](diffhunk://#diff-5e8281caf244873d624158d989f19b69fa03d9bc76f61b8af665ce7778220813R217-R219)

### Dependency and Plugin Updates:
* Added the `shared_preferences` dependency in `pubspec.yaml` and registered the corresponding plugin across macOS and Windows platforms. (`pubspec.yaml`, [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L20-L26); `macos/Flutter/GeneratedPluginRegistrant.swift`, [[2]](diffhunk://#diff-e0a0e103075365af1fb906fa24889fc5ed61c2020ef2efeb23fe020123abc325R9-R27); `windows/flutter/generated_plugin_registrant.cc`, [[3]](diffhunk://#diff-9ca3f3ddb67c9dc56635f4a7a261f461b9888c0598324eae6e6f869a4a458faeR10-R19); `windows/flutter/generated_plugins.cmake`, [[4]](diffhunk://#diff-4b55067a54dd3cd60674a36f6ce312785562c37d6eb38427e9801068b87c2297R7)

### Code Cleanup:
* Removed unused imports and added necessary ones, including `shared_preferences` and `AuthWrapperViewModel`. (`lib/main.dart`, [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L4) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R14); `lib/presentation/screens/login_screen.dart`, [[3]](diffhunk://#diff-5e8281caf244873d624158d989f19b69fa03d9bc76f61b8af665ce7778220813L10-R12)

### Updates to the Matches View:

* Introduced a logout button in the `MatchesView`, allowing users to sign out and return to the `LoginScreen`. (`lib/presentation/screens/matches_view.dart`: [lib/presentation/screens/matches_view.dartR117-R129](diffhunk://#diff-597153f56ce35790c202d1deb87de614925e2b6fe5aca0d95fe45a2bc318941cR117-R129))
