### PR TITLE
Add new user metrics

### DIFF
--- a/lib/data/services/user_metrics_service.dart
+++ b/lib/data/services/user_metrics_service.dart
@@ -1,0 +1,93 @@
+import 'dart:convert';
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+/// Handles local counting and upload of simple user metrics to New Relic.
+class UserMetricsService {
+  static const String _betKey = 'incomplete_bet_count';
+  static const String _regKey = 'incomplete_registration_count';
+
+  /// Increment the counter for users leaving the place bet view without betting.
+  static Future<void> incrementIncompleteBet() async {
+    final prefs = await SharedPreferences.getInstance();
+    final current = prefs.getInt(_betKey) ?? 0;
+    await prefs.setInt(_betKey, current + 1);
+  }
+
+  /// Increment the counter for users abandoning registration.
+  static Future<void> incrementIncompleteRegistration() async {
+    final prefs = await SharedPreferences.getInstance();
+    final current = prefs.getInt(_regKey) ?? 0;
+    await prefs.setInt(_regKey, current + 1);
+  }
+
+  /// Retrieve and clear the stored count for the given key.
+  static Future<int> _takeCount(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+    final count = prefs.getInt(key) ?? 0;
+    if (count > 0) await prefs.remove(key);
+    return count;
+  }
+
+  /// Upload any pending metric counts to New Relic.
+  static Future<void> sendPendingMetrics() async {
+    final betCount = await _takeCount(_betKey);
+    final regCount = await _takeCount(_regKey);
+
+    if (betCount == 0 && regCount == 0) return;
+
+    final logs = <Map<String, dynamic>>[];
+    final now = DateTime.now().toUtc().toIso8601String();
+
+    if (betCount > 0) {
+      logs.add({
+        'type': 'user_metric',
+        'metric': 'incomplete_bet',
+        'count': betCount,
+        'timestamp': now,
+      });
+    }
+    if (regCount > 0) {
+      logs.add({
+        'type': 'user_metric',
+        'metric': 'incomplete_registration',
+        'count': regCount,
+        'timestamp': now,
+      });
+    }
+
+    final payload = [
+      {
+        'common': {
+          'attributes': {
+            'app': 'MyFlutterApp',
+            'environment': 'prod',
+          }
+        },
+        'logs': logs,
+      }
+    ];
+
+    final uri = Uri.https('log-api.newrelic.com', '/log/v1');
+    final response = await http.post(
+      uri,
+      headers: {
+        'Api-Key': dotenv.env['NEW_RELIC_USER_LICENSE'] ?? '',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode(payload),
+    );
+
+    if (response.statusCode != 200 &&
+        response.statusCode != 201 &&
+        response.statusCode != 202) {
+      // restore counts on failure so we retry next launch
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(_betKey, (prefs.getInt(_betKey) ?? 0) + betCount);
+      await prefs.setInt(_regKey, (prefs.getInt(_regKey) ?? 0) + regCount);
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:campus_picks/data/services/isolate_manager.dart';
 import 'package:campus_picks/data/services/connectivity_service.dart';
 import 'package:campus_picks/data/services/draft_sync_service.dart';
 import 'package:campus_picks/data/services/upload_service.dart';  // ← added
+import 'package:campus_picks/data/services/user_metrics_service.dart';
 
 import 'package:campus_picks/data/models/match_model.dart';
 
@@ -142,6 +143,7 @@ Future<void> main() async {
 
   // Temporary
   await UploadService.uploadErrorLogs();
+  await UserMetricsService.sendPendingMetrics();
 }
 
 /// Routes background tasks to your upload service
@@ -150,6 +152,7 @@ void callbackDispatcher() {
   Workmanager().executeTask((task, inputData) async {
     if (task == 'uploadErrorLogs') {
       await UploadService.uploadErrorLogs();
+      await UserMetricsService.sendPendingMetrics();
     }
     return Future.value(true);
   });

--- a/lib/presentation/screens/create_account_screen.dart
+++ b/lib/presentation/screens/create_account_screen.dart
@@ -1,10 +1,13 @@
 import 'package:campus_picks/data/repositories/auth_repository.dart';
 import 'package:campus_picks/data/services/auth.dart';
 import 'package:flutter/material.dart';
+import 'dart:async';
+
 import 'package:provider/provider.dart';
 
 import '../viewmodels/user_viewmodel.dart';
 import '../../data/services/backend_api.dart';
+import '../../data/services/user_metrics_service.dart';
 
 class CreateAccountScreen extends StatefulWidget {
   final String username;
@@ -28,6 +31,7 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
   final TextEditingController phoneNumberController = TextEditingController();
   int? selectedAge;
   String selectedGender = 'Male';
+  bool _completed = false;
 
   void _submitForm() async {
     if (fullNameController.text.isEmpty ||
@@ -74,12 +78,21 @@ class _CreateAccountScreenState extends State<CreateAccountScreen> {
         SnackBar(content: Text('User created successfully: $userId')),
       );
 
+      _completed = true;
       Navigator.pop(context);
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(e.toString())),
       );
     }
+  }
+
+  @override
+  void dispose() {
+    if (!_completed) {
+      unawaited(UserMetricsService.incrementIncompleteRegistration());
+    }
+    super.dispose();
   }
 
   @override

--- a/lib/presentation/screens/place_bet_view.dart
+++ b/lib/presentation/screens/place_bet_view.dart
@@ -1,6 +1,8 @@
 // lib/presentation/screens/place_bet_view.dart
 // UPDATED – adds confirmation dialog, offline draft flag, and unconditional pop
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
@@ -11,6 +13,7 @@ import 'package:provider/provider.dart';
 import '../viewmodels/bet_viewmodel.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../viewmodels/user_bets_view_model.dart';
+import '../../data/services/user_metrics_service.dart';
 
 /// Formats numeric input as US currency with commas and two decimals
 class CurrencyInputFormatter extends TextInputFormatter {
@@ -49,11 +52,12 @@ class BetScreen extends StatefulWidget {
 class _BetScreenState extends State<BetScreen> {
   final _formKey = GlobalKey<FormState>();
   final TextEditingController _amountController = TextEditingController(
-    text: NumberFormat.currency(locale: 'en_US', symbol: '\$', decimalDigits: 2)
+    text: NumberFormat.currency(locale: 'en_US', symbol: '\\$', decimalDigits: 2)
         .format(0),
   );
   String? selectedTeam;
   late ConnectivityNotifier connectivity;
+  bool _betPlaced = false;
 
   @override
   void initState() {
@@ -64,6 +68,9 @@ class _BetScreenState extends State<BetScreen> {
   @override
   void dispose() {
     widget.viewModel.removeListener(_onVmMessage);
+    if (!_betPlaced) {
+      unawaited(UserMetricsService.incrementIncompleteBet());
+    }
     super.dispose();
   }
 
@@ -209,6 +216,7 @@ class _BetScreenState extends State<BetScreen> {
                               }
 
                               // Always pop back after we queued the bet
+                              _betPlaced = true;
                               if (mounted) Navigator.pop(context);
                             },
                       child: const Text('Submit'),


### PR DESCRIPTION
## Summary
- count incomplete bets and registrations with `UserMetricsService`
- report counters to New Relic at startup or in background tasks
- track incomplete bet count from `BetScreen`
- track incomplete registration from `CreateAccountScreen`

## Testing
- `dart format` *(fails: command not found)*
- `flutter format` *(fails: command not found)*